### PR TITLE
Add bilingual marketing website for RFIDapp

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+teuma.dev

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ supported by the iPhone).
 Plain static HTML/CSS, no build step. Serve any of these directories with a
 static file host (e.g. GitHub Pages) to publish the site.
 
+Domain: **teuma.dev** (see `CNAME`, used by GitHub Pages custom domains).
+Support email: **support@teuma.dev**.
+
 ## Before publishing
 
-- Replace the placeholder support email (`support@example.com`) in
-  `de/support.html`, `de/datenschutz.html`, `en/support.html`, `en/privacy.html`.
+- Icon is still a placeholder (`assets/img/icon.svg`) — swap in the real app
+  icon once available.
 - Review and fill in the `TODO` sections in the privacy policy pages
   (`de/datenschutz.html`, `en/privacy.html`) — they are drafts, not reviewed
-  legal text.
+  legal text (data controller name/address, and whether the app uses
+  analytics, crash reporting, iCloud sync, or ad SDKs).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # rfid-support
+
+Marketing website for **RFIDapp**, an iOS/iPadOS app for reading, managing and
+reviewing RFID/NFC tags (ISO 14443, ISO 15693, and other NFC tag types
+supported by the iPhone).
+
+## Structure
+
+- `index.html` — root redirect to `de/` or `en/` based on browser language
+- `de/`, `en/` — the German and English site (home, support, privacy policy)
+- `assets/` — shared CSS and images
+
+Plain static HTML/CSS, no build step. Serve any of these directories with a
+static file host (e.g. GitHub Pages) to publish the site.
+
+## Before publishing
+
+- Replace the placeholder support email (`support@example.com`) in
+  `de/support.html`, `de/datenschutz.html`, `en/support.html`, `en/privacy.html`.
+- Review and fill in the `TODO` sections in the privacy policy pages
+  (`de/datenschutz.html`, `en/privacy.html`) — they are drafts, not reviewed
+  legal text.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,361 @@
+/* RFIDapp — marketing site styles */
+
+:root {
+  --bg: #ffffff;
+  --bg-alt: #f5f6f8;
+  --text: #14171a;
+  --text-muted: #5b6169;
+  --accent: #0a6cff;
+  --accent-dark: #0850c4;
+  --border: #e4e7eb;
+  --card-bg: #ffffff;
+  --radius: 14px;
+  --max-width: 1080px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e1013;
+    --bg-alt: #16191d;
+    --text: #f2f3f5;
+    --text-muted: #a2a8b0;
+    --accent: #4f9cff;
+    --accent-dark: #7db4ff;
+    --border: #262a30;
+    --card-bg: #16191d;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.wrap {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+
+header.site {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+header.site .wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+  gap: 12px;
+}
+
+@media (max-width: 720px) {
+  header.site .wrap {
+    height: auto;
+    flex-wrap: wrap;
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+
+  nav.site {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    row-gap: 8px;
+    column-gap: 14px;
+    font-size: 0.9rem;
+  }
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.brand img {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+}
+
+nav.site {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  font-size: 0.95rem;
+}
+
+nav.site a {
+  color: var(--text-muted);
+}
+
+nav.site a:hover {
+  color: var(--text);
+}
+
+.lang-switch a {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.lang-switch a.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* Hero */
+
+.hero {
+  padding: 72px 0 56px;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+}
+
+.hero p.lead {
+  font-size: 1.15rem;
+  color: var(--text-muted);
+  max-width: 620px;
+  margin: 0 auto 32px;
+}
+
+.cta-row {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.98rem;
+  border: 1px solid transparent;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: var(--accent-dark);
+  text-decoration: none;
+}
+
+.btn-secondary {
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.btn-secondary:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+/* Notice / callout */
+
+.notice {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px 24px;
+  margin: 0 auto 64px;
+  max-width: 720px;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.notice strong {
+  color: var(--text);
+}
+
+/* Sections */
+
+section {
+  padding: 56px 0;
+  border-top: 1px solid var(--border);
+}
+
+section h2 {
+  font-size: 1.7rem;
+  margin: 0 0 10px;
+  text-align: center;
+}
+
+section p.section-lead {
+  text-align: center;
+  color: var(--text-muted);
+  max-width: 620px;
+  margin: 0 auto 40px;
+}
+
+/* Feature grid */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px;
+}
+
+.card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.94rem;
+}
+
+.card .icon {
+  font-size: 1.6rem;
+  margin-bottom: 10px;
+}
+
+/* Support-compatible list */
+
+.compat {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 640px) {
+  .compat {
+    grid-template-columns: 1fr;
+  }
+}
+
+.compat .card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-muted);
+  font-size: 0.94rem;
+}
+
+.compat .card.yes {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+
+/* Simple content pages (privacy / support) */
+
+.content h1 {
+  font-size: 2rem;
+  margin: 48px 0 8px;
+}
+
+.content .updated {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 32px;
+}
+
+.content h2 {
+  font-size: 1.25rem;
+  text-align: left;
+  margin: 36px 0 10px;
+}
+
+.content p, .content li {
+  color: var(--text-muted);
+}
+
+.content ul {
+  padding-left: 20px;
+}
+
+.todo {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-alt));
+  border: 1px dashed var(--accent);
+  border-radius: 10px;
+  padding: 14px 18px;
+  font-size: 0.9rem;
+  margin: 20px 0;
+}
+
+/* Footer */
+
+footer.site {
+  border-top: 1px solid var(--border);
+  padding: 32px 0;
+  margin-top: 40px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+footer.site .wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+footer.site nav {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+footer.site a {
+  color: var(--text-muted);
+}

--- a/assets/img/icon.svg
+++ b/assets/img/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="RFIDapp icon">
+  <rect width="64" height="64" rx="14" fill="#0a6cff"/>
+  <path d="M32 14a18 18 0 0 1 18 18" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+  <path d="M32 22a10 10 0 0 1 10 10" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="32" r="4" fill="#fff"/>
+</svg>

--- a/de/datenschutz.html
+++ b/de/datenschutz.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Datenschutzerklärung – RFIDapp</title>
 <meta name="description" content="Datenschutzerklärung für RFIDapp.">
+<link rel="canonical" href="https://teuma.dev/de/datenschutz.html">
 <link rel="icon" href="../assets/img/icon.svg">
 <link rel="stylesheet" href="../assets/css/style.css">
 </head>
@@ -87,8 +88,7 @@
   <h2>7. Kontakt</h2>
   <p>
     Fragen zum Datenschutz kannst du an
-    <a href="mailto:support@example.com">support@example.com</a> richten.
-    [TODO: Platzhalter-Adresse ersetzen.]
+    <a href="mailto:support@teuma.dev">support@teuma.dev</a> richten.
   </p>
 
   <h2>8. Änderungen dieser Datenschutzerklärung</h2>

--- a/de/datenschutz.html
+++ b/de/datenschutz.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Datenschutzerklärung – RFIDapp</title>
+<meta name="description" content="Datenschutzerklärung für RFIDapp.">
+<link rel="icon" href="../assets/img/icon.svg">
+<link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a class="brand" href="index.html">
+      <img src="../assets/img/icon.svg" alt="">
+      RFIDapp
+    </a>
+    <nav class="site">
+      <a href="index.html#funktionen">Funktionen</a>
+      <a href="index.html#kompatibilitaet">Kompatibilität</a>
+      <a href="support.html">Support</a>
+      <a href="datenschutz.html">Datenschutz</a>
+      <span class="lang-switch">
+        <a href="datenschutz.html" class="active">DE</a>
+        <a href="../en/privacy.html">EN</a>
+      </span>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap content">
+  <h1>Datenschutzerklärung</h1>
+  <p class="updated">Stand: 15. Juli 2026</p>
+
+  <div class="todo">
+    TODO: Dies ist ein Entwurf/Platzhalter, kein geprüfter Rechtstext. Bitte vor
+    Veröffentlichung die tatsächliche Datenverarbeitung der App (u. a. Analytics,
+    Crash-Reporting, iCloud-Sync, Werbenetzwerke) prüfen und die Angaben anpassen
+    bzw. rechtlich prüfen lassen (DSGVO / Apple-Anforderungen an App-Store-Einträge).
+  </div>
+
+  <h2>1. Verantwortlicher</h2>
+  <p>
+    [TODO: Name, Anschrift und Kontakt des Verantwortlichen gemäß Art. 4 Nr. 7 DSGVO
+    eintragen.]
+  </p>
+
+  <h2>2. Welche Daten RFIDapp verarbeitet</h2>
+  <p>
+    RFIDapp liest RFID- und NFC-Tags über die NFC-Schnittstelle des iPhones aus
+    (z. B. Tag-UID und weitere technische Kenndaten des Tags). [TODO: bestätigen –]
+    diese Daten sowie von dir angelegte Einträge, Kommentare und der Scan-Verlauf
+    werden lokal auf deinem Gerät gespeichert.
+  </p>
+  <p>
+    [TODO: Falls die App Daten an externe Server sendet, iCloud-Sync nutzt, oder
+    Dritt-SDKs (z. B. Analytics, Crash-Reporting, Werbung) einbindet, hier konkret
+    auflisten: welche Daten, zu welchem Zweck, an wen, auf welcher Rechtsgrundlage.]
+  </p>
+
+  <h2>3. Zugriff auf NFC</h2>
+  <p>
+    RFIDapp fragt beim Scannen die Berechtigung zum Zugriff auf die NFC-Schnittstelle
+    des iPhones ab. Ohne diese Berechtigung kann die App keine Tags lesen.
+  </p>
+
+  <h2>4. Weitergabe an Dritte</h2>
+  <p>
+    [TODO: Konkret angeben, ob und an wen Daten weitergegeben werden. Falls keine
+    Weitergabe stattfindet, das hier explizit so festhalten.]
+  </p>
+
+  <h2>5. Speicherdauer</h2>
+  <p>
+    Lokal gespeicherte Daten (Verlauf, Einträge) verbleiben auf deinem Gerät, bis du
+    sie löschst oder die App deinstallierst. [TODO: prüfen/anpassen.]
+  </p>
+
+  <h2>6. Deine Rechte</h2>
+  <p>
+    Du hast im Rahmen der geltenden gesetzlichen Bestimmungen das Recht auf Auskunft,
+    Berichtigung, Löschung und Einschränkung der Verarbeitung deiner Daten sowie ein
+    Beschwerderecht bei einer Aufsichtsbehörde.
+  </p>
+
+  <h2>7. Kontakt</h2>
+  <p>
+    Fragen zum Datenschutz kannst du an
+    <a href="mailto:support@example.com">support@example.com</a> richten.
+    [TODO: Platzhalter-Adresse ersetzen.]
+  </p>
+
+  <h2>8. Änderungen dieser Datenschutzerklärung</h2>
+  <p>
+    Diese Datenschutzerklärung kann bei Weiterentwicklung der App oder Änderung der
+    rechtlichen Anforderungen angepasst werden.
+  </p>
+</div>
+
+<footer class="site">
+  <div class="wrap">
+    <span>&copy; 2026 RFIDapp</span>
+    <nav>
+      <a href="index.html">Start</a>
+      <a href="support.html">Support</a>
+      <a href="../en/privacy.html">English</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/de/index.html
+++ b/de/index.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>RFIDapp – RFID- &amp; NFC-Scanner für iPhone</title>
 <meta name="description" content="RFIDapp liest, verwaltet und wertet RFID- und NFC-Tags direkt auf dem iPhone aus – ISO 14443, ISO 15693 und weitere vom iPhone unterstützte NFC-Tags.">
+<link rel="canonical" href="https://teuma.dev/de/">
+<meta property="og:title" content="RFIDapp – RFID- &amp; NFC-Scanner für iPhone">
+<meta property="og:description" content="RFIDapp liest, verwaltet und wertet RFID- und NFC-Tags direkt auf dem iPhone aus.">
+<meta property="og:url" content="https://teuma.dev/de/">
+<meta property="og:type" content="website">
 <link rel="icon" href="../assets/img/icon.svg">
 <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/de/index.html
+++ b/de/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RFIDapp – RFID- &amp; NFC-Scanner für iPhone</title>
+<meta name="description" content="RFIDapp liest, verwaltet und wertet RFID- und NFC-Tags direkt auf dem iPhone aus – ISO 14443, ISO 15693 und weitere vom iPhone unterstützte NFC-Tags.">
+<link rel="icon" href="../assets/img/icon.svg">
+<link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a class="brand" href="index.html">
+      <img src="../assets/img/icon.svg" alt="">
+      RFIDapp
+    </a>
+    <nav class="site">
+      <a href="index.html#funktionen">Funktionen</a>
+      <a href="index.html#kompatibilitaet">Kompatibilität</a>
+      <a href="support.html">Support</a>
+      <a href="datenschutz.html">Datenschutz</a>
+      <span class="lang-switch">
+        <a href="index.html" class="active">DE</a>
+        <a href="../en/index.html">EN</a>
+      </span>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="wrap">
+    <h1>RFID- &amp; NFC-Tags scannen, verwalten und auswerten</h1>
+    <p class="lead">
+      RFIDapp liest RFID- und NFC-Tags direkt mit deinem iPhone, zeigt dir klar an,
+      welcher Tagtyp erkannt wurde, und hilft dir, den Überblick über deine Scans zu behalten.
+    </p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="https://apps.apple.com/us/app/rfidapp/id6746169746">Im App Store laden</a>
+      <a class="btn btn-secondary" href="#funktionen">Funktionen ansehen</a>
+    </div>
+  </div>
+</section>
+
+<div class="wrap">
+  <div class="notice">
+    <strong>Wichtiger Hinweis:</strong> Das iPhone ist kein universelles RFID-Lesegerät.
+    RFIDapp unterstützt NFC-fähige Tags gemäß ISO 14443 und ISO 15693 sowie weitere vom
+    iPhone unterstützte NFC-Formate. Klassische 125-kHz-Tags (z. B. viele ältere
+    Zutritts- oder Tierchips) kann kein iPhone lesen – siehe
+    <a href="#kompatibilitaet">Kompatibilität</a> weiter unten.
+  </div>
+</div>
+
+<section id="funktionen">
+  <div class="wrap">
+    <h2>Funktionen</h2>
+    <p class="section-lead">RFIDapp konzentriert sich auf einen zuverlässigen, klaren Scan-Workflow.</p>
+    <div class="grid">
+      <div class="card">
+        <div class="icon">📡</div>
+        <h3>Tags scannen</h3>
+        <p>ISO 14443, ISO 15693 und weitere vom iPhone unterstützte NFC-Tags lesen.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🏷️</div>
+        <h3>Tagtyp klar erkennbar</h3>
+        <p>Die App zeigt an, welches Format erkannt und was tatsächlich gelesen wurde.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🕘</div>
+        <h3>Verlauf</h3>
+        <p>Alle gescannten Tags übersichtlich im Verlauf wiederfinden.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🔁</div>
+        <h3>Duplikaterkennung</h3>
+        <p>Bei gleicher UID nie stillschweigend überschreiben – du entscheidest, ob geöffnet, neu gespeichert oder abgebrochen wird.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🔍</div>
+        <h3>Suche per Scan</h3>
+        <p>Suche öffnen, Tag scannen, automatisch nach der UID suchen.</p>
+      </div>
+      <div class="card">
+        <div class="icon">📤</div>
+        <h3>CSV-Export</h3>
+        <p>Gescannte Daten für die Weiterverarbeitung exportieren.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="kompatibilitaet">
+  <div class="wrap">
+    <h2>Kompatibilität</h2>
+    <p class="section-lead">Damit es keine Überraschungen gibt: das liest RFIDapp – und das nicht.</p>
+    <div class="compat">
+      <div class="card yes">
+        <h3>Wird unterstützt</h3>
+        <ul>
+          <li>ISO 14443 Tags (z. B. viele Zutritts- und Ausweiskarten)</li>
+          <li>ISO 15693 Tags</li>
+          <li>Weitere NFC-Tag-Typen, die vom iPhone selbst unterstützt werden</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Wird nicht unterstützt</h3>
+        <ul>
+          <li>125-kHz-Tags (klassische LF-Transponder)</li>
+          <li>Tag-Typen, die von der iPhone-NFC-Hardware grundsätzlich nicht gelesen werden können</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap" style="text-align:center;">
+    <h2>Jetzt herunterladen</h2>
+    <p class="section-lead">RFIDapp ist im App Store verfügbar.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="https://apps.apple.com/us/app/rfidapp/id6746169746">Im App Store laden</a>
+    </div>
+  </div>
+</section>
+
+<footer class="site">
+  <div class="wrap">
+    <span>&copy; 2026 RFIDapp</span>
+    <nav>
+      <a href="support.html">Support</a>
+      <a href="datenschutz.html">Datenschutz</a>
+      <a href="../en/index.html">English</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/de/support.html
+++ b/de/support.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Support – RFIDapp</title>
 <meta name="description" content="Support und Kontakt für RFIDapp.">
+<link rel="canonical" href="https://teuma.dev/de/support.html">
 <link rel="icon" href="../assets/img/icon.svg">
 <link rel="stylesheet" href="../assets/css/style.css">
 </head>
@@ -38,12 +39,7 @@
     E-Mail schicken:
   </p>
 
-  <p><strong><a href="mailto:support@example.com">support@example.com</a></strong></p>
-
-  <div class="todo">
-    TODO: Platzhalter-Adresse durch die echte Support-E-Mail ersetzen (hier und im
-    <code>mailto:</code>-Link oben).
-  </div>
+  <p><strong><a href="mailto:support@teuma.dev">support@teuma.dev</a></strong></p>
 
   <h2>Bevor du schreibst</h2>
   <ul>

--- a/de/support.html
+++ b/de/support.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Support – RFIDapp</title>
+<meta name="description" content="Support und Kontakt für RFIDapp.">
+<link rel="icon" href="../assets/img/icon.svg">
+<link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a class="brand" href="index.html">
+      <img src="../assets/img/icon.svg" alt="">
+      RFIDapp
+    </a>
+    <nav class="site">
+      <a href="index.html#funktionen">Funktionen</a>
+      <a href="index.html#kompatibilitaet">Kompatibilität</a>
+      <a href="support.html">Support</a>
+      <a href="datenschutz.html">Datenschutz</a>
+      <span class="lang-switch">
+        <a href="support.html" class="active">DE</a>
+        <a href="../en/support.html">EN</a>
+      </span>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap content">
+  <h1>Support</h1>
+  <p class="updated">Wir helfen dir gerne weiter.</p>
+
+  <p>
+    Fragen, Fehlerberichte oder Feedback zu RFIDapp kannst du uns jederzeit per
+    E-Mail schicken:
+  </p>
+
+  <p><strong><a href="mailto:support@example.com">support@example.com</a></strong></p>
+
+  <div class="todo">
+    TODO: Platzhalter-Adresse durch die echte Support-E-Mail ersetzen (hier und im
+    <code>mailto:</code>-Link oben).
+  </div>
+
+  <h2>Bevor du schreibst</h2>
+  <ul>
+    <li>Welches iPhone-Modell und welche iOS-Version nutzt du?</li>
+    <li>Welchen Tagtyp wolltest du scannen (falls bekannt)?</li>
+    <li>Was ist passiert – und was hättest du erwartet?</li>
+  </ul>
+
+  <h2>Häufige Fragen</h2>
+  <p>
+    <strong>Warum erkennt die App meinen Tag nicht?</strong><br>
+    Das iPhone kann nur bestimmte RFID-/NFC-Tag-Typen lesen (siehe
+    <a href="index.html#kompatibilitaet">Kompatibilität</a>). Klassische 125-kHz-Tags
+    werden von keiner iPhone-App unterstützt, da die Hardware dafür fehlt.
+  </p>
+</div>
+
+<footer class="site">
+  <div class="wrap">
+    <span>&copy; 2026 RFIDapp</span>
+    <nav>
+      <a href="index.html">Start</a>
+      <a href="datenschutz.html">Datenschutz</a>
+      <a href="../en/support.html">English</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RFIDapp – RFID &amp; NFC Scanner for iPhone</title>
+<meta name="description" content="RFIDapp reads, manages and reviews RFID and NFC tags right on your iPhone – ISO 14443, ISO 15693 and other NFC tag types supported by the iPhone.">
+<link rel="icon" href="../assets/img/icon.svg">
+<link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a class="brand" href="index.html">
+      <img src="../assets/img/icon.svg" alt="">
+      RFIDapp
+    </a>
+    <nav class="site">
+      <a href="index.html#features">Features</a>
+      <a href="index.html#compatibility">Compatibility</a>
+      <a href="support.html">Support</a>
+      <a href="privacy.html">Privacy</a>
+      <span class="lang-switch">
+        <a href="../de/index.html">DE</a>
+        <a href="index.html" class="active">EN</a>
+      </span>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="wrap">
+    <h1>Scan, manage and review RFID &amp; NFC tags</h1>
+    <p class="lead">
+      RFIDapp reads RFID and NFC tags right on your iPhone, clearly shows you which
+      tag type was detected, and helps you keep track of everything you scan.
+    </p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="https://apps.apple.com/us/app/rfidapp/id6746169746">Get it on the App Store</a>
+      <a class="btn btn-secondary" href="#features">See features</a>
+    </div>
+  </div>
+</section>
+
+<div class="wrap">
+  <div class="notice">
+    <strong>Good to know:</strong> the iPhone is not a universal RFID reader.
+    RFIDapp supports NFC-based tags per ISO 14443 and ISO 15693, plus other NFC
+    formats the iPhone itself supports. Classic 125 kHz tags (e.g. many older
+    access cards or animal chips) cannot be read by any iPhone – see
+    <a href="#compatibility">Compatibility</a> below.
+  </div>
+</div>
+
+<section id="features">
+  <div class="wrap">
+    <h2>Features</h2>
+    <p class="section-lead">RFIDapp focuses on a reliable, clear scanning workflow.</p>
+    <div class="grid">
+      <div class="card">
+        <div class="icon">📡</div>
+        <h3>Scan tags</h3>
+        <p>Read ISO 14443, ISO 15693 and other NFC tag types supported by the iPhone.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🏷️</div>
+        <h3>Clear tag type detection</h3>
+        <p>The app shows which format was detected and what was actually read.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🕘</div>
+        <h3>History</h3>
+        <p>Find every scanned tag again in a clear history view.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🔁</div>
+        <h3>Duplicate detection</h3>
+        <p>Same UID never gets silently overwritten – you choose to open the existing entry, save a new one anyway, or cancel.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🔍</div>
+        <h3>Search by scan</h3>
+        <p>Open search, scan a tag, and automatically search by its UID.</p>
+      </div>
+      <div class="card">
+        <div class="icon">📤</div>
+        <h3>CSV export</h3>
+        <p>Export your scanned data for further processing.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="compatibility">
+  <div class="wrap">
+    <h2>Compatibility</h2>
+    <p class="section-lead">No surprises: here's what RFIDapp can read – and what it can't.</p>
+    <div class="compat">
+      <div class="card yes">
+        <h3>Supported</h3>
+        <ul>
+          <li>ISO 14443 tags (e.g. many access and ID cards)</li>
+          <li>ISO 15693 tags</li>
+          <li>Other NFC tag types supported by the iPhone itself</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Not supported</h3>
+        <ul>
+          <li>125 kHz tags (classic LF transponders)</li>
+          <li>Tag types that the iPhone's NFC hardware fundamentally cannot read</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap" style="text-align:center;">
+    <h2>Download now</h2>
+    <p class="section-lead">RFIDapp is available on the App Store.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="https://apps.apple.com/us/app/rfidapp/id6746169746">Get it on the App Store</a>
+    </div>
+  </div>
+</section>
+
+<footer class="site">
+  <div class="wrap">
+    <span>&copy; 2026 RFIDapp</span>
+    <nav>
+      <a href="support.html">Support</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="../de/index.html">Deutsch</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/en/index.html
+++ b/en/index.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>RFIDapp – RFID &amp; NFC Scanner for iPhone</title>
 <meta name="description" content="RFIDapp reads, manages and reviews RFID and NFC tags right on your iPhone – ISO 14443, ISO 15693 and other NFC tag types supported by the iPhone.">
+<link rel="canonical" href="https://teuma.dev/en/">
+<meta property="og:title" content="RFIDapp – RFID &amp; NFC Scanner for iPhone">
+<meta property="og:description" content="RFIDapp reads, manages and reviews RFID and NFC tags right on your iPhone.">
+<meta property="og:url" content="https://teuma.dev/en/">
+<meta property="og:type" content="website">
 <link rel="icon" href="../assets/img/icon.svg">
 <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Privacy Policy – RFIDapp</title>
+<meta name="description" content="Privacy policy for RFIDapp.">
+<link rel="icon" href="../assets/img/icon.svg">
+<link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a class="brand" href="index.html">
+      <img src="../assets/img/icon.svg" alt="">
+      RFIDapp
+    </a>
+    <nav class="site">
+      <a href="index.html#features">Features</a>
+      <a href="index.html#compatibility">Compatibility</a>
+      <a href="support.html">Support</a>
+      <a href="privacy.html">Privacy</a>
+      <span class="lang-switch">
+        <a href="../de/datenschutz.html">DE</a>
+        <a href="privacy.html" class="active">EN</a>
+      </span>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap content">
+  <h1>Privacy Policy</h1>
+  <p class="updated">Last updated: July 15, 2026</p>
+
+  <div class="todo">
+    TODO: this is a draft/placeholder, not reviewed legal text. Before publishing,
+    please confirm the app's actual data handling (analytics, crash reporting,
+    iCloud sync, ad networks) and adjust these statements, then have them reviewed
+    (GDPR and Apple App Store requirements).
+  </div>
+
+  <h2>1. Controller</h2>
+  <p>
+    [TODO: add the name, address and contact details of the data controller.]
+  </p>
+
+  <h2>2. What data RFIDapp processes</h2>
+  <p>
+    RFIDapp reads RFID and NFC tags via the iPhone's NFC interface (e.g. the tag's
+    UID and other technical tag data). [TODO: confirm –] this data, along with any
+    entries, comments and the scan history you create, is stored locally on your
+    device.
+  </p>
+  <p>
+    [TODO: if the app sends data to any server, uses iCloud sync, or includes
+    third-party SDKs (analytics, crash reporting, advertising), list them
+    explicitly here: what data, for what purpose, shared with whom, and on what
+    legal basis.]
+  </p>
+
+  <h2>3. NFC access</h2>
+  <p>
+    RFIDapp requests permission to access the iPhone's NFC interface when scanning.
+    Without this permission the app cannot read tags.
+  </p>
+
+  <h2>4. Sharing with third parties</h2>
+  <p>
+    [TODO: state explicitly whether and with whom data is shared. If no data is
+    shared, state that explicitly.]
+  </p>
+
+  <h2>5. Data retention</h2>
+  <p>
+    Locally stored data (history, entries) stays on your device until you delete it
+    or uninstall the app. [TODO: confirm/adjust.]
+  </p>
+
+  <h2>6. Your rights</h2>
+  <p>
+    Depending on applicable law, you may have the right to access, correct, delete,
+    or restrict processing of your data, and the right to lodge a complaint with a
+    supervisory authority.
+  </p>
+
+  <h2>7. Contact</h2>
+  <p>
+    Questions about privacy can be sent to
+    <a href="mailto:support@example.com">support@example.com</a>.
+    [TODO: replace placeholder address.]
+  </p>
+
+  <h2>8. Changes to this policy</h2>
+  <p>
+    This privacy policy may be updated as the app evolves or legal requirements
+    change.
+  </p>
+</div>
+
+<footer class="site">
+  <div class="wrap">
+    <span>&copy; 2026 RFIDapp</span>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="support.html">Support</a>
+      <a href="../de/datenschutz.html">Deutsch</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy – RFIDapp</title>
 <meta name="description" content="Privacy policy for RFIDapp.">
+<link rel="canonical" href="https://teuma.dev/en/privacy.html">
 <link rel="icon" href="../assets/img/icon.svg">
 <link rel="stylesheet" href="../assets/css/style.css">
 </head>
@@ -87,8 +88,7 @@
   <h2>7. Contact</h2>
   <p>
     Questions about privacy can be sent to
-    <a href="mailto:support@example.com">support@example.com</a>.
-    [TODO: replace placeholder address.]
+    <a href="mailto:support@teuma.dev">support@teuma.dev</a>.
   </p>
 
   <h2>8. Changes to this policy</h2>

--- a/en/support.html
+++ b/en/support.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Support – RFIDapp</title>
+<meta name="description" content="Support and contact for RFIDapp.">
+<link rel="icon" href="../assets/img/icon.svg">
+<link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a class="brand" href="index.html">
+      <img src="../assets/img/icon.svg" alt="">
+      RFIDapp
+    </a>
+    <nav class="site">
+      <a href="index.html#features">Features</a>
+      <a href="index.html#compatibility">Compatibility</a>
+      <a href="support.html">Support</a>
+      <a href="privacy.html">Privacy</a>
+      <span class="lang-switch">
+        <a href="../de/support.html">DE</a>
+        <a href="support.html" class="active">EN</a>
+      </span>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap content">
+  <h1>Support</h1>
+  <p class="updated">We're happy to help.</p>
+
+  <p>
+    For questions, bug reports, or feedback about RFIDapp, reach out any time by
+    email:
+  </p>
+
+  <p><strong><a href="mailto:support@example.com">support@example.com</a></strong></p>
+
+  <div class="todo">
+    TODO: replace this placeholder address with the real support email (here and in
+    the <code>mailto:</code> link above).
+  </div>
+
+  <h2>Before you write</h2>
+  <ul>
+    <li>Which iPhone model and iOS version are you using?</li>
+    <li>Which tag type were you trying to scan (if known)?</li>
+    <li>What happened, and what did you expect instead?</li>
+  </ul>
+
+  <h2>Frequently asked questions</h2>
+  <p>
+    <strong>Why doesn't the app recognize my tag?</strong><br>
+    The iPhone can only read certain RFID/NFC tag types (see
+    <a href="index.html#compatibility">Compatibility</a>). Classic 125 kHz tags
+    aren't supported by any iPhone app, since the hardware for it simply isn't there.
+  </p>
+</div>
+
+<footer class="site">
+  <div class="wrap">
+    <span>&copy; 2026 RFIDapp</span>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="../de/support.html">Deutsch</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/en/support.html
+++ b/en/support.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Support – RFIDapp</title>
 <meta name="description" content="Support and contact for RFIDapp.">
+<link rel="canonical" href="https://teuma.dev/en/support.html">
 <link rel="icon" href="../assets/img/icon.svg">
 <link rel="stylesheet" href="../assets/css/style.css">
 </head>
@@ -38,12 +39,7 @@
     email:
   </p>
 
-  <p><strong><a href="mailto:support@example.com">support@example.com</a></strong></p>
-
-  <div class="todo">
-    TODO: replace this placeholder address with the real support email (here and in
-    the <code>mailto:</code> link above).
-  </div>
+  <p><strong><a href="mailto:support@teuma.dev">support@teuma.dev</a></strong></p>
 
   <h2>Before you write</h2>
   <ul>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=de/index.html">
+<title>RFIDapp</title>
+<link rel="icon" href="assets/img/icon.svg">
+<script>
+  (function () {
+    var lang = (navigator.language || "de").toLowerCase();
+    var target = lang.indexOf("de") === 0 ? "de/index.html" : "en/index.html";
+    window.location.replace(target);
+  })();
+</script>
+</head>
+<body>
+  <p>RFIDapp &mdash; <a href="de/index.html">Deutsch</a> / <a href="en/index.html">English</a></p>
+</body>
+</html>


### PR DESCRIPTION
Static HTML/CSS site with home, support, and privacy policy pages in
German and English, plus a language-detecting root redirect. Covers
app features, iPhone NFC/RFID compatibility, and links to the App
Store listing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01977VUNBTDFha3dJnYwoBWj