### PR TITLE
Add bilingual RFIDapp marketing website (teuma.dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Support email: **support@teuma.dev**.
 
 - Icon is still a placeholder (`assets/img/icon.svg`) — swap in the real app
   icon once available.
-- Review and fill in the `TODO` sections in the privacy policy pages
-  (`de/datenschutz.html`, `en/privacy.html`) — they are drafts, not reviewed
-  legal text (data controller name/address, and whether the app uses
-  analytics, crash reporting, iCloud sync, or ad SDKs).
+- Privacy policy (`de/datenschutz.html`, `en/privacy.html`) is filled in with
+  the controller's details and current data-handling practice, but is not
+  reviewed by a lawyer — worth a final legal check before going live,
+  especially once analytics, surveys, or collaboration features are added.

--- a/de/datenschutz.html
+++ b/de/datenschutz.html
@@ -34,30 +34,33 @@
   <h1>Datenschutzerklärung</h1>
   <p class="updated">Stand: 15. Juli 2026</p>
 
-  <div class="todo">
-    TODO: Dies ist ein Entwurf/Platzhalter, kein geprüfter Rechtstext. Bitte vor
-    Veröffentlichung die tatsächliche Datenverarbeitung der App (u. a. Analytics,
-    Crash-Reporting, iCloud-Sync, Werbenetzwerke) prüfen und die Angaben anpassen
-    bzw. rechtlich prüfen lassen (DSGVO / Apple-Anforderungen an App-Store-Einträge).
-  </div>
-
   <h2>1. Verantwortlicher</h2>
   <p>
-    [TODO: Name, Anschrift und Kontakt des Verantwortlichen gemäß Art. 4 Nr. 7 DSGVO
-    eintragen.]
+    Artem Wilhelmi<br>
+    Römerstraße 9<br>
+    77933 Lahr/Schwarzwald<br>
+    E-Mail: <a href="mailto:support@teuma.dev">support@teuma.dev</a>
   </p>
 
   <h2>2. Welche Daten RFIDapp verarbeitet</h2>
   <p>
     RFIDapp liest RFID- und NFC-Tags über die NFC-Schnittstelle des iPhones aus
-    (z. B. Tag-UID und weitere technische Kenndaten des Tags). [TODO: bestätigen –]
-    diese Daten sowie von dir angelegte Einträge, Kommentare und der Scan-Verlauf
-    werden lokal auf deinem Gerät gespeichert.
+    (z. B. Tag-UID und weitere technische Kenndaten des Tags). Diese Daten sowie von
+    dir angelegte Einträge, Kommentare und der Scan-Verlauf werden lokal auf deinem
+    Gerät gespeichert.
   </p>
   <p>
-    [TODO: Falls die App Daten an externe Server sendet, iCloud-Sync nutzt, oder
-    Dritt-SDKs (z. B. Analytics, Crash-Reporting, Werbung) einbindet, hier konkret
-    auflisten: welche Daten, zu welchem Zweck, an wen, auf welcher Rechtsgrundlage.]
+    Im aktuellen Stand der App werden keine Analyse- oder Tracking-Dienste,
+    Crash-Reporting-Dienste, kein iCloud-Sync und keine Werbenetzwerke eingebunden.
+    Es findet keine Übertragung deiner Tag- oder Verlaufsdaten an externe Server
+    statt.
+  </p>
+  <p>
+    Es ist möglich, dass zukünftige Versionen der App weitere Funktionen ergänzen,
+    die eine Datenverarbeitung erfordern – etwa eine anonymisierte Auswertung der
+    Feature-Nutzung, freiwillige Umfragen in der App, oder Funktionen für die
+    Zusammenarbeit mehrerer Nutzer. Sollte eine solche Funktion eingeführt werden,
+    wird diese Datenschutzerklärung vorab entsprechend aktualisiert.
   </p>
 
   <h2>3. Zugriff auf NFC</h2>
@@ -68,14 +71,13 @@
 
   <h2>4. Weitergabe an Dritte</h2>
   <p>
-    [TODO: Konkret angeben, ob und an wen Daten weitergegeben werden. Falls keine
-    Weitergabe stattfindet, das hier explizit so festhalten.]
+    Im aktuellen Stand der App werden keine Daten an Dritte weitergegeben.
   </p>
 
   <h2>5. Speicherdauer</h2>
   <p>
     Lokal gespeicherte Daten (Verlauf, Einträge) verbleiben auf deinem Gerät, bis du
-    sie löschst oder die App deinstallierst. [TODO: prüfen/anpassen.]
+    sie löschst oder die App deinstallierst.
   </p>
 
   <h2>6. Deine Rechte</h2>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -34,30 +34,30 @@
   <h1>Privacy Policy</h1>
   <p class="updated">Last updated: July 15, 2026</p>
 
-  <div class="todo">
-    TODO: this is a draft/placeholder, not reviewed legal text. Before publishing,
-    please confirm the app's actual data handling (analytics, crash reporting,
-    iCloud sync, ad networks) and adjust these statements, then have them reviewed
-    (GDPR and Apple App Store requirements).
-  </div>
-
   <h2>1. Controller</h2>
   <p>
-    [TODO: add the name, address and contact details of the data controller.]
+    Artem Wilhelmi<br>
+    Römerstraße 9<br>
+    77933 Lahr/Schwarzwald, Germany<br>
+    Email: <a href="mailto:support@teuma.dev">support@teuma.dev</a>
   </p>
 
   <h2>2. What data RFIDapp processes</h2>
   <p>
     RFIDapp reads RFID and NFC tags via the iPhone's NFC interface (e.g. the tag's
-    UID and other technical tag data). [TODO: confirm –] this data, along with any
-    entries, comments and the scan history you create, is stored locally on your
-    device.
+    UID and other technical tag data). This data, along with any entries, comments
+    and the scan history you create, is stored locally on your device.
   </p>
   <p>
-    [TODO: if the app sends data to any server, uses iCloud sync, or includes
-    third-party SDKs (analytics, crash reporting, advertising), list them
-    explicitly here: what data, for what purpose, shared with whom, and on what
-    legal basis.]
+    In the app's current state, no analytics or tracking services, crash-reporting
+    services, iCloud sync, or advertising networks are integrated. Your tag or
+    history data is not transmitted to any external server.
+  </p>
+  <p>
+    Future versions of the app may add features that require additional data
+    processing — for example an anonymized evaluation of feature usage, optional
+    in-app surveys, or collaboration features for multiple users. If such a feature
+    is introduced, this privacy policy will be updated in advance accordingly.
   </p>
 
   <h2>3. NFC access</h2>
@@ -68,14 +68,13 @@
 
   <h2>4. Sharing with third parties</h2>
   <p>
-    [TODO: state explicitly whether and with whom data is shared. If no data is
-    shared, state that explicitly.]
+    In the app's current state, no data is shared with third parties.
   </p>
 
   <h2>5. Data retention</h2>
   <p>
     Locally stored data (history, entries) stays on your device until you delete it
-    or uninstall the app. [TODO: confirm/adjust.]
+    or uninstall the app.
   </p>
 
   <h2>6. Your rights</h2>


### PR DESCRIPTION
## Summary
- Static HTML/CSS marketing site for RFIDapp in German and English (home, support, privacy policy)
- Home page covers app features and clearly communicates iPhone NFC/RFID tag compatibility (ISO 14443, ISO 15693; no 125 kHz support)
- Privacy policy filled in with the data controller's details and the app's actual current data handling (local storage only, no analytics/iCloud sync/ads/third-party sharing), with a note that it will be updated in advance if future features (usage analytics, in-app surveys, collaboration) are added
- `CNAME` for the `teuma.dev` custom domain, canonical/OG meta tags pointing at it
- Root `index.html` redirects to `de/` or `en/` based on browser language

## Test plan
- [x] Verified DE/EN pages render correctly (desktop + mobile) via headless-browser screenshots
- [x] Checked HTML tag balance across all pages
- [ ] Enable GitHub Pages (Settings → Pages, source: `main`) and confirm `teuma.dev` resolves once DNS propagates
- [ ] Swap placeholder app icon (`assets/img/icon.svg`) for the real one

---
_Generated by [Claude Code](https://claude.ai/code/session_01977VUNBTDFha3dJnYwoBWj)_